### PR TITLE
Add configurable timeout option for pod startup

### DIFF
--- a/support/ibm-events-must-gather
+++ b/support/ibm-events-must-gather
@@ -14,6 +14,7 @@ function compactUsage() {
     echo "  -i: The address of the image to be used for the gather. By default this uses icr.io/cpopen/ibm-events-must-gather."
     echo "  -m: Define the data module(s) that specifies what type of information is collected. Run with -h, to see full list of available data modules."
     echo "  -n: Specify the namespace from which the data is collected. If specifying more than one of eventstreams, eem, eventprocessing and flink modules, individual namespace flags must be used."
+    echo "  -w: The duration in seconds to wait for the mustgather pod to start before failing (default 300)."
     echo "  --mustgather-namespace: Specify the namespace for mustgather pod."
     echo "  --image-pull-secret: Specify single image pull secret."
     echo "  --es-namespace: The namespace from which the eventstreams data is collected."
@@ -224,6 +225,9 @@ while [[ $# -gt 0 ]]; do
     "-i") image="$2"
           shift 2
           ;;
+    "-w") timeout="$2"
+          shift 2
+          ;;
     "--mustgather-namespace") mustgatherPodNamespace="$2"
           shift 2
           ;;
@@ -367,6 +371,8 @@ setup
 
 kubectl apply -f must-gather-job.yaml
 
+
+TIMEOUT=${timeout=300}
 PODS=""
 i=0
 while : ; do
@@ -374,7 +380,7 @@ while : ; do
   if [ "$PODS" ]; then
       break
   fi
-  if [ $i -gt 300 ]; then
+  if [ $i -gt $TIMEOUT ]; then
       echo "The must gather pods failed to start correctly. Please try again and if the problem persists contact IBM support for further advice."
       LOGDIR="./must-gather-failure-logs"
       mkdir "${LOGDIR}"


### PR DESCRIPTION
Adds a configurable timeout option for environments where the image pull may take some time and the pod is therefore slow to start after deployment.  Option is specified using `-w` for wait.