### PR TITLE
feat: update flink config for quick-start sample

### DIFF
--- a/flink/cr-examples/flinkdeployment/kubernetes/quick-start.yaml
+++ b/flink/cr-examples/flinkdeployment/kubernetes/quick-start.yaml
@@ -17,6 +17,10 @@ spec:
     state.checkpoints.num-retained: '3'
     taskmanager.numberOfTaskSlots: '4'
     table.exec.source.idle-timeout: '30 s'
+    restart-strategy: failure-rate
+    restart-strategy.failure-rate.max-failures-per-interval: '5'
+    restart-strategy.failure-rate.failure-rate-interval: '5 min'
+    restart-strategy.failure-rate.delay: '30 s'
   serviceAccount: flink
   podTemplate:
     apiVersion: v1

--- a/flink/cr-examples/flinkdeployment/openshift/quick-start.yaml
+++ b/flink/cr-examples/flinkdeployment/openshift/quick-start.yaml
@@ -12,6 +12,10 @@ spec:
     state.checkpoints.num-retained: '3'
     taskmanager.numberOfTaskSlots: '4'
     table.exec.source.idle-timeout: '30 s'
+    restart-strategy: failure-rate
+    restart-strategy.failure-rate.max-failures-per-interval: '5'
+    restart-strategy.failure-rate.failure-rate-interval: '5 min'
+    restart-strategy.failure-rate.delay: '30 s'
   serviceAccount: flink
   podTemplate:
     apiVersion: v1


### PR DESCRIPTION
- explicitly set restart-strategry.type to failure-rate
- max 5 failures on a 5 mins interval