### PR TITLE
Update event-processing Flink UDF samples

### DIFF
--- a/event-processing/flink-examples/udf/Dockerfile
+++ b/event-processing/flink-examples/udf/Dockerfile
@@ -1,5 +1,6 @@
+ARG FLINK_IMAGE=none
+FROM ${FLINK_IMAGE}
+
 ARG UDF_JAR
-ARG FLINK_IMAGE
-FROM --platform=linux/amd64 ${FLINK_IMAGE}
 COPY --chown=flink:root target/${UDF_JAR} /opt/flink/lib
 COPY --chown=flink:root sql/sentences.ndjson /tmp/sentences.ndjson

--- a/event-processing/flink-examples/udf/README.md
+++ b/event-processing/flink-examples/udf/README.md
@@ -5,8 +5,7 @@ This repository contains examples and samples that demonstrate how to use Flink 
 
 - Java 11
 - Java Integrated Development Environment (IDE)
-- [Docker](https://github.com/docker/compose/releases) version 2.24.5 or later
-- `linux/amd64` platform.
+- [Docker](https://github.com/docker/compose/releases) version 2.24.5 or later 
 
 ## Deploying and running the functions on a Flink cluster
 

--- a/event-processing/flink-examples/udf/build-flink-image.sh
+++ b/event-processing/flink-examples/udf/build-flink-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 IBM Corp. All Rights Reserved.
+# Copyright 2024, 2026 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,33 +18,33 @@ set -e
 
 function usage() {
   echo "Augments an IBM Flink image with the User-Defined Functions (UDF) JAR."
-  echo "Syntax: $(basename ${0}) <IBM_FLINK_IMAGE>"
+  echo "Syntax: $(basename "${0}") <IBM_FLINK_IMAGE>"
 }
 
-function udfJarName() {
-  local projectAbsolutePath=$(cd "$(dirname "$0")" && pwd)
-  local artifactId=$(mvn help:evaluate -Dexpression="project.artifactId" -q -DforceStdout -f "${projectAbsolutePath}/pom.xml")
-  local version=$(mvn help:evaluate -Dexpression="project.version" -q -DforceStdout -f "${projectAbsolutePath}/pom.xml")
-  printf "%s-%s.jar" ${artifactId} ${version}
+function udfJar() {
+  local projectAbsolutePath="$1"
+  local artifactId
+  local version
+  artifactId="$(mvn help:evaluate -Dexpression="project.artifactId" -q -DforceStdout -f "${projectAbsolutePath}/pom.xml")"
+  version="$(mvn help:evaluate -Dexpression="project.version" -q -DforceStdout -f "${projectAbsolutePath}/pom.xml")"
+  printf "%s-%s.jar" "${artifactId}" "${version}"
 }
 
 function main() {
-  local projectAbsolutePath=$(cd "$(dirname "$0")" && pwd)
+  local ibmflinkImage=${1:?"Error: No IBM Flink image provided."}
+  local projectAbsolutePath
+  local udfJarName
+  local udfJarPath
 
-  local ibmflinkImage=${1}
-  if [ -z "${ibmflinkImage}" ]; then
-    echo >&2 "Error: No IBM Flink image provided."
-    usage
+  projectAbsolutePath="$(cd "$(dirname "$0")" && pwd)"
+  udfJarName="$(udfJar "${projectAbsolutePath}")"
+  udfJarPath="${projectAbsolutePath}/target/$udfJarName"
+  if [ ! -f "${udfJarPath}" ]; then
+    echo >&2 "Error: file ${udfJarPath} not found, build the Maven project first."
     exit 1
   fi
 
-  local udfJar="${projectAbsolutePath}/target/$(udfJarName)"
-  if [ ! -f "${udfJar}" ]; then
-    echo >&2 "Error: file ${udfJar} not found, build the Maven project first."
-    exit 1
-  fi
-
-  docker build ${projectAbsolutePath} -t flink-with-udf:latest --build-arg UDF_JAR="${udfJarName}" --build-arg FLINK_IMAGE="${ibmflinkImage}"
+  docker build "${projectAbsolutePath}" -t flink-with-udf:latest --build-arg UDF_JAR="${udfJarName}" --build-arg FLINK_IMAGE="${ibmflinkImage}"
 }
 
 main "$@"

--- a/event-processing/flink-examples/udf/flink-cluster.sh
+++ b/event-processing/flink-examples/udf/flink-cluster.sh
@@ -57,7 +57,7 @@ function main() {
         exit 1
       fi
       echo "Executing ${sqlFile}... (it might take a few minutes to complete)"
-      docker compose -f ${currentDir}/docker-compose/docker-compose.yaml exec sp-flink bash -c "/opt/flink/bin/sql-client.sh -f /var/host/${sqlFile}"
+      docker compose -f ${currentDir}/docker-compose/docker-compose.yaml exec sp-flink bash -c "/opt/flink/bin/sql-client.sh --jar /opt/flink/ibm-ep-job-dependencies/ibm-ep-job-dependencies.jar -f /var/host/${sqlFile}"
       ;;
      
     *)

--- a/event-processing/flink-examples/udf/pom.xml
+++ b/event-processing/flink-examples/udf/pom.xml
@@ -12,7 +12,7 @@
 	<name>udf-examples</name>
 
 	<properties>
-		<flink.version>1.18.1</flink.version>
+		<flink.version>2.2.0</flink.version>
 		<java.version>11</java.version>
         <junit.version>5.10.2</junit.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
- upgrade Flink dependency to 2.2.0
- fix build-flink-image.sh path to UDF jar in docker image
- includes latest changes:
  - docker `platform` no more required since EP Flink image supports `linux/arm64` 
  - set `--jar /opt/flink/ibm-ep-job-dependencies/ibm-ep-job-dependencies.jar` by default when deploying SQL