### PR TITLE
[Event Processing] Add timestamp UDF CI and release workflows

### DIFF
--- a/.github/workflows/timestamp-udf-pr.yml
+++ b/.github/workflows/timestamp-udf-pr.yml
@@ -1,0 +1,32 @@
+name: Timestamp UDF PR validation
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - event-processing/timestamp-udf/**
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test-timestamp-udf:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      - name: Build and test timestamp UDF module
+        working-directory: event-processing/timestamp-udf
+        run: mvn --batch-mode clean verify

--- a/.github/workflows/timestamp-udf-release.yml
+++ b/.github/workflows/timestamp-udf-release.yml
@@ -1,0 +1,52 @@
+name: Timestamp UDF release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  publish-timestamp-udf-jar:
+    if: startsWith(github.event.release.tag_name, 'timestamp-udf-v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      - name: Derive release version from tag
+        id: version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#timestamp-udf-v}"
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "${TAG_NAME}" ]; then
+            echo "Unsupported tag format: ${TAG_NAME}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set Maven project version
+        working-directory: event-processing/timestamp-udf
+        run: mvn --batch-mode versions:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Build jar
+        working-directory: event-processing/timestamp-udf
+        run: mvn --batch-mode clean package
+
+      - name: Upload jar asset to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            event-processing/timestamp-udf/target/ibm-ep-udf.jar \
+            --clobber


### PR DESCRIPTION
This PR adds the GitHub Actions workflows needed to validate and publish the timestamp UDF module that will be introduced in follow-up PR #78.

### Scope

This PR adds:

- [`.github/workflows/timestamp-udf-pr.yml`](.github/workflows/timestamp-udf-pr.yml)
- [`.github/workflows/timestamp-udf-release.yml`](.github/workflows/timestamp-udf-release.yml)

### Intent / use cases

The timestamp UDF module is planned to be added under `event-processing/timestamp-udf` so customers can download the jar, inspect the source, and rebuild the module if needed. Publishing to a Maven repository is intentionally out of scope.

These workflows support two concrete use cases:

1. **PR validation**
   - when maintainers update the public module, changes should be automatically built and tested in PRs before merge

2. **Release publication**
   - when maintainers decide to publish a module version, they should be able to create a GitHub Release and have the jar automatically built and attached as a release asset for customer download

### Workflow boundaries

PR validation workflow:
- runs on `pull_request`
- triggers only when files under `event-processing/timestamp-udf/**` change
- builds and runs unit tests
- does not publish releases or assets

Release workflow:
- runs when a GitHub Release is published
- only proceeds for tags starting with `timestamp-udf-v`
- builds, runs unit tests, and publishes the jar asset
- does not create the release
- does not publish to a Maven repository

### Notes

- This PR intentionally does **not** add the module content itself.
- The module will be introduced in a follow-up PR.
- Publishing a release remains a manual action through GitHub Releases.

### Why separate this from the module PR

The split allows the workflows to be introduced first, so the follow-up PR can run through the new validation workflow. It also makes it possible to configure `Require status checks to pass` later once the check has run upstream.
