### PR TITLE
Fix timestamp UDF PR check blocking unrelated PRs

### DIFF
--- a/.github/workflows/timestamp-udf-pr.yml
+++ b/.github/workflows/timestamp-udf-pr.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths:
-      - event-processing/timestamp-udf/**
 
 permissions:
   contents: read
@@ -19,8 +17,18 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for timestamp-udf changes
+        id: changes
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^event-processing/timestamp-udf/' \
+            && echo "relevant=true" >> "${GITHUB_OUTPUT}" \
+            || echo "relevant=false" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Java
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -28,5 +36,6 @@ jobs:
           cache: maven
 
       - name: Build and test timestamp UDF module
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: event-processing/timestamp-udf
         run: mvn --batch-mode clean verify


### PR DESCRIPTION
Fixes an issue where the `build-and-test-timestamp-udf` required status check was left permanently pending on PRs that did not touch [`event-processing/timestamp-udf/**`](event-processing/timestamp-udf), blocking their merge.

With this fix:

- PRs not touching [`event-processing/timestamp-udf/**`](event-processing/timestamp-udf): workflow runs, path check passes immediately, Java/Maven steps are skipped
- PRs touching [`event-processing/timestamp-udf/**`](event-processing/timestamp-udf): full build and test runs as before