### PR TITLE
fix: Switch to requiring Confluent for Kubernetes

### DIFF
--- a/event-processing/migration-tools/FlinkApplication.yaml
+++ b/event-processing/migration-tools/FlinkApplication.yaml
@@ -1,8 +1,10 @@
-apiVersion: cmf.confluent.io/v1
+apiVersion: platform.confluent.io/v1beta1
 kind: FlinkApplication
 metadata:
   name: ${APP_NAME}
+  namespace: ${NAMESPACE}
 spec:
+  flinkEnvironment: ${FLINK_ENV}
   image: ${APP_IMAGE}
   imagePullPolicy: Always
   flinkVersion: v2_1
@@ -55,3 +57,6 @@ spec:
     parallelism: 1
     upgradeMode: ${UPGRADE_MODE}
     initialSavepointPath: ${SAVEPOINT_PATH}
+  cmfRestClassRef:
+    name: ${CMF_REST_CLASS}
+    namespace: ${CMF_REST_CLASS_NS}

--- a/event-processing/migration-tools/deploy.sh
+++ b/event-processing/migration-tools/deploy.sh
@@ -5,9 +5,9 @@
 #   ./deploy.sh [options]
 #
 # Options (all optional — omitted values are prompted interactively):
-#   --name                <name>       Application name (OpenShift resource name)
+#   --name                <name>       Application name (Kubernetes resource name)
 #   --image               <image>      Docker image, e.g. myregistry.io/flink-flow:v1
-#   --namespace           <namespace>  OpenShift namespace to deploy into
+#   --namespace           <namespace>  Kubernetes namespace to deploy into
 #   --flink-env           <env>        FlinkEnvironment CR name
 #   --pvc                 <pvc>        PersistentVolumeClaim name for Flink state storage
 #   --savepoint           <path>       Savepoint path for state migration (e.g. file:///opt/flink/...)
@@ -144,7 +144,7 @@ fi
 
 if [[ -z "$APP_NAME" ]]; then
   label "Application name"
-  hint "A short OpenShift resource name, e.g. 'customer-orders-flow'."
+  hint "A short Kubernetes resource name, e.g. 'customer-orders-flow'."
   hint "Must be unique within the namespace."
   APP_NAME=$(ask "Name")
   br
@@ -153,15 +153,15 @@ fi
 if [[ -z "$APP_IMAGE" ]]; then
   label "Image"
   hint "The image you built with the provided Dockerfile."
-  hint "Must be accessible from your OpenShift cluster, e.g. 'myregistry.io/flink-flow:v1'."
+  hint "Must be accessible from your Kubernetes cluster, e.g. 'myregistry.io/flink-flow:v1'."
   APP_IMAGE=$(ask "Image")
 fi
 
 if [[ -z "$NAMESPACE" ]]; then
-  header "OpenShift namespace"
+  header "Kubernetes namespace"
   br
   label "Namespace"
-  hint "The OpenShift namespace to deploy the FlinkApplication into."
+  hint "The Kubernetes namespace to deploy the FlinkApplication into."
   hint "List namespaces with: $KC get namespaces"
   NAMESPACE=$(ask "Namespace")
 fi

--- a/event-processing/migration-tools/deploy.sh
+++ b/event-processing/migration-tools/deploy.sh
@@ -1,35 +1,57 @@
 #!/usr/bin/env bash
-# deploy.sh — deploy a migrated IBM EP flow to Confluent Platform Flink
+# deploy.sh — deploy a migrated IBM EP flow to Confluent Platform for Apache Flink, using Confluent for Kubernetes
 #
 # Usage:
 #   ./deploy.sh [options]
 #
 # Options (all optional — omitted values are prompted interactively):
-#   --name        <name>       Application name (Kubernetes resource name)
-#   --image       <image>      Docker image, e.g. myregistry.io/flink-flow:v1
-#   --env         <env>        CMF environment name
-#   --pvc         <pvc>        PersistentVolumeClaim name for Flink state storage
-#   --savepoint   <path>       Savepoint path for state migration (e.g. file:///opt/flink/...)
-#                              Omit for a fresh deployment (no state restore).
-#   --dry-run                  Print the rendered YAML instead of submitting it.
+#   --name                <name>       Application name (OpenShift resource name)
+#   --image               <image>      Docker image, e.g. myregistry.io/flink-flow:v1
+#   --namespace           <namespace>  OpenShift namespace to deploy into
+#   --flink-env           <env>        FlinkEnvironment CR name
+#   --pvc                 <pvc>        PersistentVolumeClaim name for Flink state storage
+#   --savepoint           <path>       Savepoint path for state migration (e.g. file:///opt/flink/...)
+#                                      Omit for a fresh deployment (no state restore).
+#   --cmfrestclass        <name>       CMFRestClass CR name (default: "default")
+#   --cmfrestclass-namespace <ns>      Namespace of the CMFRestClass CR (default: same as --namespace)
+#   --dry-run                          Print the rendered YAML instead of submitting it.
 #
 # Examples:
 #   # Interactive (prompts for all values):
 #   ./deploy.sh
 #
 #   # Fully non-interactive:
-#   ./deploy.sh --name my-flow --image myregistry.io/flink-flow:v1 --env test --pvc my-pvc
+#   ./deploy.sh --name my-flow --image myregistry.io/flink-flow:v1 \
+#     --namespace flink --flink-env my-env --pvc my-pvc
 #
 #   # With state migration:
-#   ./deploy.sh --name my-flow --image myregistry.io/flink-flow:v1 --env test --pvc my-pvc \
+#   ./deploy.sh --name my-flow --image myregistry.io/flink-flow:v1 \
+#     --namespace flink --flink-env my-env --pvc my-pvc \
 #     --savepoint file:///opt/flink/volume/flink-sp/savepoint-e574c6-638b6089cdd2
 #
-# Requires: confluent CLI, logged in and targeting the correct Kubernetes context.
+#   # With a non-default CMFRestClass in a different namespace:
+#   ./deploy.sh --name my-flow --image myregistry.io/flink-flow:v1 \
+#     --namespace flink --flink-env my-env --pvc my-pvc \
+#     --cmfrestclass my-class --cmfrestclass-namespace operator
+#
+# Requires: oc (preferred) or kubectl, logged in and targeting the correct cluster.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATE="$SCRIPT_DIR/FlinkApplication.yaml"
+
+# =============================================================================
+# Detect oc vs kubectl
+# =============================================================================
+if command -v oc &>/dev/null; then
+  KC=oc
+elif command -v kubectl &>/dev/null; then
+  KC=kubectl
+else
+  echo "Error: Neither 'oc' nor 'kubectl' found on PATH." >&2
+  exit 1
+fi
 
 # =============================================================================
 # Formatting
@@ -51,19 +73,25 @@ br()      { echo ""; }
 # =============================================================================
 APP_NAME=""
 APP_IMAGE=""
-CMF_ENV=""
+NAMESPACE=""
+FLINK_ENV=""
 PVC_NAME=""
 SAVEPOINT_PATH=""
+CMF_REST_CLASS=""
+CMF_REST_CLASS_NS=""
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --name)       APP_NAME="$2";      shift 2 ;;
-    --image)      APP_IMAGE="$2";     shift 2 ;;
-    --env)        CMF_ENV="$2";       shift 2 ;;
-    --pvc)        PVC_NAME="$2";      shift 2 ;;
-    --savepoint)  SAVEPOINT_PATH="$2"; shift 2 ;;
-    --dry-run)    DRY_RUN=true;       shift   ;;
+    --name)                   APP_NAME="$2";          shift 2 ;;
+    --image)                  APP_IMAGE="$2";         shift 2 ;;
+    --namespace)              NAMESPACE="$2";         shift 2 ;;
+    --flink-env)              FLINK_ENV="$2";         shift 2 ;;
+    --pvc)                    PVC_NAME="$2";          shift 2 ;;
+    --savepoint)              SAVEPOINT_PATH="$2";    shift 2 ;;
+    --cmfrestclass)           CMF_REST_CLASS="$2";    shift 2 ;;
+    --cmfrestclass-namespace) CMF_REST_CLASS_NS="$2"; shift 2 ;;
+    --dry-run)                DRY_RUN=true;           shift   ;;
     *) echo "Unknown option: $1" >&2; exit 1  ;;
   esac
 done
@@ -101,7 +129,7 @@ ask_yn() {
 # Collect any missing values interactively
 # =============================================================================
 interactive=false
-[[ -z "$APP_NAME" || -z "$APP_IMAGE" || -z "$CMF_ENV" || -z "$PVC_NAME" ]] && interactive=true
+[[ -z "$APP_NAME" || -z "$APP_IMAGE" || -z "$NAMESPACE" || -z "$FLINK_ENV" || -z "$PVC_NAME" ]] && interactive=true
 
 if $interactive; then
   echo ""
@@ -116,7 +144,7 @@ fi
 
 if [[ -z "$APP_NAME" ]]; then
   label "Application name"
-  hint "A short Kubernetes resource name, e.g. 'customer-orders-flow'."
+  hint "A short OpenShift resource name, e.g. 'customer-orders-flow'."
   hint "Must be unique within the namespace."
   APP_NAME=$(ask "Name")
   br
@@ -125,16 +153,25 @@ fi
 if [[ -z "$APP_IMAGE" ]]; then
   label "Image"
   hint "The image you built with the provided Dockerfile."
-  hint "Must be accessible from your Kubernetes cluster, e.g. 'myregistry.io/flink-flow:v1'."
+  hint "Must be accessible from your OpenShift cluster, e.g. 'myregistry.io/flink-flow:v1'."
   APP_IMAGE=$(ask "Image")
 fi
 
-if [[ -z "$CMF_ENV" ]]; then
-  header "CMF environment"
+if [[ -z "$NAMESPACE" ]]; then
+  header "OpenShift namespace"
   br
-  label "CMF environment name"
-  hint "List available environments with: confluent flink environment list"
-  CMF_ENV=$(ask "Environment name")
+  label "Namespace"
+  hint "The OpenShift namespace to deploy the FlinkApplication into."
+  hint "List namespaces with: $KC get namespaces"
+  NAMESPACE=$(ask "Namespace")
+fi
+
+if [[ -z "$FLINK_ENV" ]]; then
+  header "Flink environment"
+  br
+  label "FlinkEnvironment CR name"
+  hint "List available environments with: $KC get flinkenvironment -A"
+  FLINK_ENV=$(ask "Flink environment name")
 fi
 
 if [[ -z "$PVC_NAME" ]]; then
@@ -175,12 +212,21 @@ fi
 # =============================================================================
 # Render template
 # =============================================================================
-export APP_NAME APP_IMAGE PVC_NAME UPGRADE_MODE SAVEPOINT_PATH
+# Apply defaults for optional CMFRestClass fields
+CMF_REST_CLASS="${CMF_REST_CLASS:-default}"
+CMF_REST_CLASS_NS="${CMF_REST_CLASS_NS:-}"
+
+export APP_NAME APP_IMAGE NAMESPACE FLINK_ENV PVC_NAME UPGRADE_MODE SAVEPOINT_PATH CMF_REST_CLASS CMF_REST_CLASS_NS
 
 rendered=$(envsubst < "$TEMPLATE")
 
 if [[ -z "$SAVEPOINT_PATH" ]]; then
   rendered=$(echo "$rendered" | grep -v '^\s*initialSavepointPath:')
+fi
+
+# Strip the cmfRestClassRef namespace line when using the default (same namespace)
+if [[ -z "$CMF_REST_CLASS_NS" ]]; then
+  rendered=$(echo "$rendered" | grep -v '^\s*namespace:\s*$')
 fi
 
 # =============================================================================
@@ -190,10 +236,12 @@ if $interactive || $DRY_RUN; then
   echo ""
   echo "────────────────────────────────────────────────────────"
   echo "${bold}Summary${reset}"
-  echo "  CMF environment  : ${bold}$CMF_ENV${reset}"
+  echo "  Namespace        : ${bold}$NAMESPACE${reset}"
+  echo "  Flink environment: ${bold}$FLINK_ENV${reset}"
   echo "  Application name : ${bold}$APP_NAME${reset}"
   echo "  Image            : ${bold}$APP_IMAGE${reset}"
   echo "  PVC              : ${bold}$PVC_NAME${reset}"
+  echo "  CMFRestClass     : ${bold}${CMF_REST_CLASS:-default} (ns: ${CMF_REST_CLASS_NS:-$NAMESPACE})${reset}"
   if [[ -n "$SAVEPOINT_PATH" ]]; then
     echo "  Savepoint        : ${bold}$SAVEPOINT_PATH${reset}"
   else
@@ -227,9 +275,9 @@ tmpfile=$(mktemp /tmp/flink-application-XXXXXX.yaml)
 trap 'rm -f "$tmpfile"' EXIT
 echo "$rendered" > "$tmpfile"
 
-confluent --environment "$CMF_ENV" flink application create "$tmpfile"
+$KC apply -f "$tmpfile"
 
 br
 success "Done."
 echo "Monitor your application with:"
-echo "  confluent --environment $CMF_ENV flink application describe $APP_NAME"
+echo "  $KC get flinkApplication $APP_NAME -n $NAMESPACE -o yaml"


### PR DESCRIPTION
Change deploy.sh so that rather than `confluent flink application create` new apps we require Confluent for Kubernetes, and create a `FlinkApplication` custom resource instead. This should give a more familiar user experience, and integrate more smoothly into existing workflows. 